### PR TITLE
Update Sourcery template for version 0.10.1 with Mint package manager

### DIFF
--- a/Sources/App/Models/City/City.generated.swift
+++ b/Sources/App/Models/City/City.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/Client/Client.generated.swift
+++ b/Sources/App/Models/Client/Client.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/Content/Content.generated.swift
+++ b/Sources/App/Models/Content/Content.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/Creator/Creator.generated.swift
+++ b/Sources/App/Models/Creator/Creator.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/Event/Event.generated.swift
+++ b/Sources/App/Models/Event/Event.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/EventReg/EventReg.generated.swift
+++ b/Sources/App/Models/EventReg/EventReg.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/EventRegAnswer/EventRegAnswer.generated.swift
+++ b/Sources/App/Models/EventRegAnswer/EventRegAnswer.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/EventRegField/EventRegField.generated.swift
+++ b/Sources/App/Models/EventRegField/EventRegField.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/GiveSpeech/GiveSpeech.generated.swift
+++ b/Sources/App/Models/GiveSpeech/GiveSpeech.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/Heartbeat/Heartbeat.generated.swift
+++ b/Sources/App/Models/Heartbeat/Heartbeat.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/Migration/Migration.generated.swift
+++ b/Sources/App/Models/Migration/Migration.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/Place/Place.generated.swift
+++ b/Sources/App/Models/Place/Place.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/RegField/RegField.generated.swift
+++ b/Sources/App/Models/RegField/RegField.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/RegFieldAnswer/RegFieldAnswer.generated.swift
+++ b/Sources/App/Models/RegFieldAnswer/RegFieldAnswer.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/RegFieldRule/RegFieldRule.generated.swift
+++ b/Sources/App/Models/RegFieldRule/RegFieldRule.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/RegForm/RegForm.generated.swift
+++ b/Sources/App/Models/RegForm/RegForm.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/Session/Session.generated.swift
+++ b/Sources/App/Models/Session/Session.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/Social/Social.generated.swift
+++ b/Sources/App/Models/Social/Social.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/SocialAccount/SocialAccount.generated.swift
+++ b/Sources/App/Models/SocialAccount/SocialAccount.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/Speaker/Speaker.generated.swift
+++ b/Sources/App/Models/Speaker/Speaker.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/Speech/Speech.generated.swift
+++ b/Sources/App/Models/Speech/Speech.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Sources/App/Models/User/User.generated.swift
+++ b/Sources/App/Models/User/User.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Vapor

--- a/Templates/AutoModelGeneratable.stencil
+++ b/Templates/AutoModelGeneratable.stencil
@@ -3,7 +3,7 @@
 
 {% macro AddEntity type %}
 extension {{ type.name }} {
-  static var entity: String = "{{ type.name|lowerFirst|camelToSnakeCase }}"
+  static var entity: String = "{{ type.name|lowerFirstLetter|camelToSnakeCase }}"
 }
 {% endmacro %}
 
@@ -160,7 +160,7 @@ extension {{ type.name }}: Updateable {
 {% endmacro %}
 
 {% macro ImplicitForeignRelation variable %}
-      builder.foreignId(for: {{ variable.name|replace:"Id",""|upperFirst }}.self, optional: {% if variable.isOptional %}true{% else %}false{% endif %}, unique: {{ variable.annotations.unique|default:"false" }}, foreignIdKey: Keys.{{ variable.name }})
+      builder.foreignId(for: {{ variable.name|replace:"Id",""|upperFirstLetter }}.self, optional: {% if variable.isOptional %}true{% else %}false{% endif %}, unique: {{ variable.annotations.unique|default:"false" }}, foreignIdKey: Keys.{{ variable.name }})
 {% endmacro %}
 
 {% macro PlainType variable %}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 #if os(Linux)
@@ -20,11 +20,8 @@ extension EventControllerTests {
   static var allTests: [(String, (EventControllerTests) -> () throws -> Void)] = [
    ("testThatEventHasPlaceRelation", testThatEventHasPlaceRelation),
    ("testThatPlaceOfEventHasCityRelation", testThatPlaceOfEventHasCityRelation),
-   ("testThatIndexEventsFailsForEmptyQueryParameters", testThatIndexEventsFailsForEmptyQueryParameters),
    ("testThatIndexEventsReturnsOkStatusForBeforeQueryKey", testThatIndexEventsReturnsOkStatusForBeforeQueryKey),
    ("testThatIndexEventsReturnsOkStatusForAfterQueryKey", testThatIndexEventsReturnsOkStatusForAfterQueryKey),
-   ("testThatIndexEventsFailsForIncorrectQueryKey", testThatIndexEventsFailsForIncorrectQueryKey),
-   ("testThatIndexEventsFailsForNonDateQueryValue", testThatIndexEventsFailsForNonDateQueryValue),
    ("testThatIndexEventsReturnsJSONArray", testThatIndexEventsReturnsJSONArray),
    ("testThatIndexEventsReturnsJSONArrayEventsHasAllRequiredFields", testThatIndexEventsReturnsJSONArrayEventsHasAllRequiredFields),
    ("testThatIndexEventsReturnsJSONArrayEventsHasAllExpectedFields", testThatIndexEventsReturnsJSONArrayEventsHasAllExpectedFields),
@@ -33,6 +30,7 @@ extension EventControllerTests {
    ("testThatIndexEventsReturnsCorrectNumberOfPastAndComingEvents", testThatIndexEventsReturnsCorrectNumberOfPastAndComingEvents),
    ("testThatGetEventsBeforeTimestampRouteReturnsOkStatus", testThatGetEventsBeforeTimestampRouteReturnsOkStatus),
    ("testThatGetEventsAfterTimestampRouteReturnsOkStatus", testThatGetEventsAfterTimestampRouteReturnsOkStatus),
+   ("testThatGetEventsRouteFailsForEmptyQueryParameters", testThatGetEventsRouteFailsForEmptyQueryParameters),
    ("testThatGetEventsRouteFailsWithWrongQueryParameterKey", testThatGetEventsRouteFailsWithWrongQueryParameterKey),
    ("testThatGetEventsRouteFailsWithWrongQueryParameterValue", testThatGetEventsRouteFailsWithWrongQueryParameterValue)
   ]
@@ -40,15 +38,15 @@ extension EventControllerTests {
 extension EventSpeechControllerTests {
   static var allTests: [(String, (EventSpeechControllerTests) -> () throws -> Void)] = [
    ("testThatIndexSpeechesReturnsOkStatus", testThatIndexSpeechesReturnsOkStatus),
-   ("testThatIndexSpeechesFailsForEmptyTable", testThatIndexSpeechesFailsForEmptyTable),
    ("testThatIndexSpeechesFailsWithIncorrectParameter", testThatIndexSpeechesFailsWithIncorrectParameter),
-   ("testThatIndexSpeechesFailsWithNonIntParameterValue", testThatIndexSpeechesFailsWithNonIntParameterValue),
    ("testThatIndexSpeechesReturnsJSONWithAllRequiredFields", testThatIndexSpeechesReturnsJSONWithAllRequiredFields),
    ("testThatIndexSpeechesReturnsJSONWithExpectedFields", testThatIndexSpeechesReturnsJSONWithExpectedFields),
    ("testThatIndexSpeechesReturnsCorrectSpeechesCount", testThatIndexSpeechesReturnsCorrectSpeechesCount),
    ("testThatIndexSpeechesReturnsCorrectSpeakersCount", testThatIndexSpeechesReturnsCorrectSpeakersCount),
    ("testThatIndexSpeechesReturnsCorrectContentsCount", testThatIndexSpeechesReturnsCorrectContentsCount),
-   ("testThatGetSpeechesRouteReturnsOkStatus", testThatGetSpeechesRouteReturnsOkStatus)
+   ("testThatGetSpeechesRouteReturnsOkStatus", testThatGetSpeechesRouteReturnsOkStatus),
+   ("testThatGetSpeechesRouteFailsForEmptyTable", testThatGetSpeechesRouteFailsForEmptyTable),
+   ("testThatGetSpeechesRouteFailsWithNonIntParameterValue", testThatGetSpeechesRouteFailsWithNonIntParameterValue)
   ]
 }
 extension HeartbeatControllerTests {


### PR DESCRIPTION
Using sourcery with brew package manager caused some problems. 
So we move to fresh [Mint package manager](https://github.com/yonaskolb/Mint) for Swift packages. 

Instruction for move to Mint: 

* Remove currently installed Sourcery(if was installed)
`brew uninstall sourcery`
* Download Mint Package manager 
`brew tap yonaskolb/Mint https://github.com/yonaskolb/Mint.git`
`brew install mint`
* Download latest Sourcery package with Mint 
`mint install krzysztofzablocki/Sourcery`
